### PR TITLE
Fix donut chart not updating for a new dataset

### DIFF
--- a/src/modules/donut/donut.js
+++ b/src/modules/donut/donut.js
@@ -173,7 +173,15 @@ angular.module('dangle')
                                     });
 
                             // run the transition
-                            path.transition().duration(duration).attrTween('d', arcTween);
+                            path
+                                .style('fill', function(d) { return color(d.data.term); })
+                            .transition()
+                                .duration(duration)
+                                .attrTween('d', arcTween)
+                                .style('fill', function(d) { return color(d.data.term); });
+
+                            // remove arcs not in the dataset
+                            path.exit().remove();
 
                             // update the label ticks
                             var ticks = labels.selectAll('line').data(pieData);


### PR DESCRIPTION
1/ Keep the color based on object constancy
2/ Remove arcs which are not present in the data anymore on `exit()`

Tested manually.
